### PR TITLE
Add basic grid validation to Sudoku Puzzle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,5 +74,8 @@ RSpec/NestedGroups:
 RSpec/ExpectChange:
   EnforcedStyle: block
 
+Style/AsciiComments:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false

--- a/api/app/models/puzzle.rb
+++ b/api/app/models/puzzle.rb
@@ -3,5 +3,17 @@
 class Puzzle < ApplicationRecord
   self.implicit_order_column = :created_at
 
-  validates :definition, presence: true
+  validate :validate_grid
+
+  def sudoku_grid
+    @sudoku_grid ||= Sudoku::Grid.new(definition)
+  end
+
+  private
+
+  def validate_grid
+    return if sudoku_grid.valid?
+
+    sudoku_grid.formatted_errors.each { |error| errors.add(:base, error) }
+  end
 end

--- a/api/config/locales/sudoku_grid.en.yml
+++ b/api/config/locales/sudoku_grid.en.yml
@@ -1,0 +1,9 @@
+en:
+  sudoku_grid:
+    validator:
+      invalid_length: "Puzzle has an invalid length of %{length}. Valid lengths are: %{valid_lengths}"
+      empty_puzzle: "Puzzle is empty!"
+      invalid_digits: "Puzzle has invalid digits: %{digits}. Valid digits are: %{valid_digits}"
+      duplicate_in_row: "Digit %{digit} repeats in row %{row}. It must be unique in that row"
+      duplicate_in_col: "Digit %{digit} repeats in column %{col}. It must be unique in that column"
+      duplicate_in_block: "Digit %{digit} repeats in block %{block}. It must be unique in that block"

--- a/api/lib/sudoku/cell.rb
+++ b/api/lib/sudoku/cell.rb
@@ -4,8 +4,6 @@ module Sudoku
   class Cell
     attr_reader :value, :frozen, :row, :col, :block, :peers, :grid_size, :candidates
 
-    ROW_NAMES = ('A'..'I').to_a.freeze
-
     def initialize(value:, row:, col:, block:, grid:)
       @value      = value.to_i.zero? ? nil : value.to_i
       @frozen     = @value.present?
@@ -57,9 +55,7 @@ module Sudoku
     end
 
     def position_name
-      row_name = ROW_NAMES[row.index]
-      col_name = col.index + 1
-      "#{row_name}#{col_name}"
+      "#{row.name}#{col.name}"
     end
 
     def to_s

--- a/api/lib/sudoku/grid.rb
+++ b/api/lib/sudoku/grid.rb
@@ -3,11 +3,12 @@
 module Sudoku
   class Grid
     include Sudoku::Grid::Printer
+    include Sudoku::Grid::Validator
 
     attr_reader :cells, :rows, :cols, :blocks, :units, :grid_size, :sub_grid_size, :numbers
 
     def initialize(grid_string)
-      grid_values = grid_string.split('')
+      grid_values = grid_string.to_s.split('')
       @grid_size = Math.sqrt(grid_values.size).to_i
       @sub_grid_size = Math.sqrt(grid_size).to_i
       @numbers = grid_size.times.map { |n| n + 1 }
@@ -30,16 +31,16 @@ module Sudoku
     private
 
     def build_grid(grid_values)
-      @rows   = build_units
-      @cols   = build_units
-      @blocks = build_units
+      @rows   = build_units(:row)
+      @cols   = build_units(:col)
+      @blocks = build_units(:block)
       @units  = rows.values + cols.values + blocks.values
       @cells  = build_cells(grid_values)
       cells.each(&:find_peers)
     end
 
-    def build_units
-      grid_size.times.each_with_object({}) { |index, result| result[index] = Sudoku::Unit.new(index) }
+    def build_units(type)
+      grid_size.times.each_with_object({}) { |index, result| result[index] = Sudoku::Unit.new(index, type) }
     end
 
     def build_cells(values)

--- a/api/lib/sudoku/grid/printer.rb
+++ b/api/lib/sudoku/grid/printer.rb
@@ -11,10 +11,8 @@ module Sudoku
       # sub_grid_size rows (3 rows for classic Sudoku), a separator row is printed to separate the blocks.
       # The "join(print_separator_row)" method is used to avoid a trailing separator row at the end.
       def print
-        rows.values.in_groups_of(sub_grid_size).each_with_index.map do |row_group, row_group_index|
-          printed_rows = row_group.each_with_index.map do |row, row_index|
-            print_row(row, (row_group_index * sub_grid_size) + row_index)
-          end
+        rows.values.in_groups_of(sub_grid_size).each.map do |row_group|
+          printed_rows = row_group.each.map(&method(:print_row))
           [print_separator_row, printed_rows].join
         end.unshift(print_header_row)
       end
@@ -24,12 +22,11 @@ module Sudoku
       # Returns a formatted row, with blocks separated by VERTICAL_SEPARATORS, and with a newline character at the end.
       # In classic Sudoku, a block is three cells wide and tall, so between each three cells there's a separator.
       # The "join(' ')" method is used to avoid a trailing separator at the end.
-      def print_row(row, index)
-        row_name = Sudoku::Cell::ROW_NAMES[index]
+      def print_row(row)
         printed_row = row.cells.in_groups_of(sub_grid_size).map do |cell_group|
           cell_group.map { |cell| cell.value || '.' }.join(' ')
         end
-        "#{row_name}#{VERTICAL_SEPARATOR}#{printed_row.join(VERTICAL_SEPARATOR)}\n"
+        "#{row.name}#{VERTICAL_SEPARATOR}#{printed_row.join(VERTICAL_SEPARATOR)}\n"
       end
 
       def print_header_row

--- a/api/lib/sudoku/grid/validator.rb
+++ b/api/lib/sudoku/grid/validator.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Sudoku
+  class Grid
+    module Validator
+      VALID_LENGTHS = [16, 81].freeze
+
+      def valid?
+        @errors = []
+
+        validate_presence
+        validate_length
+        validate_digits
+        validate_rows
+        validate_cols
+        validate_blocks
+
+        @errors.empty?
+      end
+
+      def errors
+        @errors
+      end
+
+      def formatted_errors
+        errors.map do |error|
+          I18n.t("sudoku_grid.validator.#{error[:name]}", error)
+        end
+      end
+
+      private
+
+      def validate_presence
+        return if current_definition.present?
+
+        @errors << { name: :empty_puzzle }
+      end
+
+      def validate_length
+        return if VALID_LENGTHS.include?(cells.size)
+
+        @errors << { name: :invalid_length, length: cells.size, valid_lengths: VALID_LENGTHS.join(', ') }
+      end
+
+      def validate_digits
+        valid_digits = ([0] + numbers).map(&:to_s)
+        invalid_digits = current_definition.split('').reject { |digit| valid_digits.include?(digit) }
+        return if invalid_digits.blank?
+
+        @errors << { name: :invalid_digits, digits: invalid_digits.join(', '), valid_digits: valid_digits.join(', ') }
+      end
+
+      def validate_rows
+        rows.values.each(&method(:validate_unit))
+      end
+
+      def validate_cols
+        cols.values.each(&method(:validate_unit))
+      end
+
+      def validate_blocks
+        blocks.values.each(&method(:validate_unit))
+      end
+
+      def validate_unit(unit)
+        numbers_count = unit.cells.map(&:value).tally
+        duplicate_numbers = numbers_count.reject { |number, count| count <= 1 || number.nil? }.keys
+        return if duplicate_numbers.empty?
+
+        add_duplicate_unit_errors(unit, duplicate_numbers)
+      end
+
+      def add_duplicate_unit_errors(unit, duplicate_numbers)
+        unit_type = unit.type
+        duplicate_numbers.each do |duplicate|
+          @errors << { name: "duplicate_in_#{unit_type}".to_sym, digit: duplicate }.tap do |error_hash|
+            error_hash[unit_type.to_sym] = unit.name
+          end
+        end
+      end
+    end
+  end
+end

--- a/api/lib/sudoku/unit.rb
+++ b/api/lib/sudoku/unit.rb
@@ -2,11 +2,14 @@
 
 module Sudoku
   class Unit
-    attr_reader :cells, :index
+    attr_reader :cells, :index, :type
 
-    def initialize(index)
+    ROW_NAMES = ('A'..'I').to_a.freeze
+
+    def initialize(index, type)
       @cells = []
       @index = index
+      @type  = type
     end
 
     def value_solved?(value)
@@ -15,6 +18,12 @@ module Sudoku
 
     def unsolved_cells
       cells.reject(&:solved?)
+    end
+
+    def name
+      return ROW_NAMES[index] if type == :row
+
+      (index + 1).to_s
     end
   end
 end

--- a/api/spec/controllers/puzzles_controller_spec.rb
+++ b/api/spec/controllers/puzzles_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe PuzzlesController, type: :controller, aggregate_failures: true do
         {
           name:       'MyPuzzle',
           author:     'Myself',
-          definition: '123456789'
+          definition: '0003000230004000'
         }
       end
 
@@ -46,7 +46,7 @@ RSpec.describe PuzzlesController, type: :controller, aggregate_failures: true do
 
         expect(json_response['puzzle']['name']).to eq 'MyPuzzle'
         expect(json_response['puzzle']['author']).to eq 'Myself'
-        expect(json_response['puzzle']['definition']).to eq '123456789'
+        expect(json_response['puzzle']['definition']).to eq '0003000230004000'
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe PuzzlesController, type: :controller, aggregate_failures: true do
 
         expect(json_response['puzzle']['name']).to eq 'MyPuzzle'
         expect(json_response['puzzle']['author']).to eq 'Myself'
-        expect(json_response['errors']).to eq ['Definition can\'t be blank']
+        expect(json_response['errors']).to include 'Puzzle is empty!'
       end
     end
   end
@@ -103,7 +103,7 @@ RSpec.describe PuzzlesController, type: :controller, aggregate_failures: true do
 
         expect(json_response['puzzle']['name']).to eq 'MyPuzzle'
         expect(json_response['puzzle']['definition']).to eq ''
-        expect(json_response['errors']).to eq ['Definition can\'t be blank']
+        expect(json_response['errors']).to include 'Puzzle is empty!'
       end
     end
   end

--- a/api/spec/factories/puzzles_factory.rb
+++ b/api/spec/factories/puzzles_factory.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :puzzle do
-    definition { Array.new(81).map { (1..9).to_a.sample }.join }
+    definition { '0003000230004000' }
   end
 end

--- a/api/spec/lib/sudoku/cell_spec.rb
+++ b/api/spec/lib/sudoku/cell_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Sudoku::Cell, type: :model do
   let(:cell) { described_class.new(value: initial_value, row: row, col: col, block: block, grid: grid) }
 
   let(:initial_value) { 9 }
-  let(:row) { instance_double(Sudoku::Unit, index: 1) }
-  let(:col) { instance_double(Sudoku::Unit, index: 2) }
-  let(:block) { instance_double(Sudoku::Unit, index: 3) }
+  let(:row) { instance_double(Sudoku::Unit, name: 'B') }
+  let(:col) { instance_double(Sudoku::Unit, name: '3') }
+  let(:block) { instance_double(Sudoku::Unit, name: '4') }
   let(:grid) { instance_double(Sudoku::Grid, grid_size: 9) }
 
   describe 'Ivar assignment' do

--- a/api/spec/lib/sudoku/grid/validator_spec.rb
+++ b/api/spec/lib/sudoku/grid/validator_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+RSpec.describe Sudoku::Grid::Validator, type: :model do
+  let(:grid) { Sudoku::Grid.new(definition) }
+
+  describe '#valid?' do
+    subject(:validation_result) { grid.valid? }
+
+    let(:errors) do
+      validation_result
+      grid.errors
+    end
+
+    let(:formatted_errors) do
+      validation_result
+      grid.formatted_errors
+    end
+
+    context 'when the puzzle is valid' do
+      # 0 0 │ 0 3
+      # 0 0 │ 0 2
+      # ────┼────
+      # 3 0 │ 0 0
+      # 4 0 │ 0 0
+      let(:definition) { '0003000230004000' }
+
+      it { is_expected.to be_truthy }
+      it { expect(errors).to be_empty }
+    end
+
+    context 'when the puzzle is invalid' do
+      let(:definition) { '001002003' }
+
+      it 'multiple calls to valid? should not stack errors' do
+        grid.valid?
+        grid.valid?
+        grid.valid?
+        expect(errors.size).to eq 1
+      end
+    end
+
+    context 'when the puzzle has an invalid length' do
+      let(:definition) { '001002003' }
+
+      it { is_expected.to be_falsey }
+      it { expect(errors).to include(name: :invalid_length, length: 9, valid_lengths: '16, 81') }
+      it { expect(formatted_errors).to include('Puzzle has an invalid length of 9. Valid lengths are: 16, 81') }
+    end
+
+    context 'when the puzzle is nil' do
+      let(:definition) { nil }
+
+      it { is_expected.to be_falsey }
+      it { expect(errors).to include(name: :empty_puzzle) }
+      it { expect(formatted_errors).to include('Puzzle is empty!') }
+    end
+
+    context 'when the puzzle contains invalid characters' do
+      # 9 0 │ 0 3
+      # 0 0 │ 0 2
+      # ────┼────
+      # 3 0 │ 0 0
+      # 4 0 │ 0 Z
+      let(:definition) { '9003000230004000' }
+
+      it { is_expected.to be_falsey }
+      it { expect(errors).to include(name: :invalid_digits, digits: '9', valid_digits: '0, 1, 2, 3, 4') }
+      it { expect(formatted_errors).to include('Puzzle has invalid digits: 9. Valid digits are: 0, 1, 2, 3, 4') }
+    end
+
+    context 'when one of the rows has duplicate digits' do
+      # 0 3 │ 0 3
+      # 0 0 │ 0 2
+      # ────┼────
+      # 3 0 │ 0 0
+      # 4 0 │ 0 0
+      let(:definition) { '0303000230004000' }
+
+      it { is_expected.to be_falsey }
+      it { expect(errors).to include(name: :duplicate_in_row, digit: 3, row: 'A') }
+      it { expect(formatted_errors).to include('Digit 3 repeats in row A. It must be unique in that row') }
+    end
+
+    context 'when one of the columns has duplicate digits' do
+      # 0 1 │ 0 3
+      # 0 0 │ 0 2
+      # ────┼────
+      # 0 1 │ 0 0
+      # 4 0 │ 0 0
+      let(:definition) { '0103000231004000' }
+
+      it { is_expected.to be_falsey }
+      it { expect(errors).to include(name: :duplicate_in_col, digit: 1, col: '2') }
+      it { expect(formatted_errors).to include('Digit 1 repeats in column 2. It must be unique in that column') }
+    end
+
+    context 'when one of the units has duplicate digits' do
+      # 0 0 │ 0 3
+      # 0 0 │ 0 2
+      # ────┼────
+      # 3 4 │ 0 0
+      # 4 0 │ 0 0
+      let(:definition) { '0003000234004000' }
+
+      it { is_expected.to be_falsey }
+      it { expect(errors).to include(name: :duplicate_in_block, digit: 4, block: '3') }
+      it { expect(formatted_errors).to include('Digit 4 repeats in block 3. It must be unique in that block') }
+    end
+
+    context 'when one of the rows has multiple duplicate digits' do
+      # 1 3 │ 1 3
+      # 0 0 │ 0 2
+      # ────┼────
+      # 3 0 │ 0 0
+      # 4 0 │ 0 0
+      let(:definition) { '1313000230004000' }
+
+      it { is_expected.to be_falsey }
+      it { expect(errors).to include(name: :duplicate_in_row, digit: 1, row: 'A') }
+      it { expect(errors).to include(name: :duplicate_in_row, digit: 3, row: 'A') }
+      it { expect(formatted_errors).to include('Digit 1 repeats in row A. It must be unique in that row') }
+      it { expect(formatted_errors).to include('Digit 3 repeats in row A. It must be unique in that row') }
+    end
+  end
+end

--- a/api/spec/lib/sudoku/unit_spec.rb
+++ b/api/spec/lib/sudoku/unit_spec.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe Sudoku::Unit, type: :model do
-  let(:unit) { described_class.new(index) }
+  let(:unit) { described_class.new(index, type) }
 
   let(:index) { 0 }
+  let(:type) { :row }
 
   describe 'Ivar assignment' do
     it { expect(unit.instance_variable_get(:@cells)).to eq [] }
     it { expect(unit.instance_variable_get(:@index)).to eq index }
+    it { expect(unit.instance_variable_get(:@type)).to eq type }
   end
 
   describe '#value_solved?' do

--- a/api/spec/models/puzzle_spec.rb
+++ b/api/spec/models/puzzle_spec.rb
@@ -11,6 +11,23 @@ RSpec.describe Puzzle, type: :model do
     it { is_expected.not_to validate_presence_of(:name) }
     it { is_expected.not_to validate_presence_of(:author) }
     it { is_expected.not_to validate_presence_of(:slug) }
-    it { is_expected.to validate_presence_of(:definition) }
+
+    context 'when definition is for a valid puzzle' do
+      let(:attributes) { { definition: '0003000230004000' } }
+
+      before { puzzle.valid? }
+
+      it { expect(puzzle).to be_valid }
+      it { expect(puzzle.errors).to be_blank }
+    end
+
+    context 'when definition is for an invalid puzzle' do
+      let(:attributes) { { definition: nil } }
+
+      before { puzzle.valid? }
+
+      it { expect(puzzle).not_to be_valid }
+      it { expect(puzzle.errors).to be_present }
+    end
   end
 end


### PR DESCRIPTION
This PR adds a validator to `Grid, plugs it into the `Puzzle` validation and closes #15.

It validates:

* Puzzle presence and length (valid lengths are 16 and 81, for 2x2 and 3x3 sudokus)
* Digits validation (2x2 can be 0-4 and 3x3 can be 0-9)
* Row, col, and block uniqueness validation, numbers can't repeat in the same unit