### PR TITLE
Create static grid to render a "thumbnail" Sudoku puzzle

### DIFF
--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -22,9 +22,8 @@ module.exports = {
     'comma-dangle': ['error', 'always-multiline'],
     'space-before-function-paren': ['error', 'never'],
     'no-unused-vars': ['warn'],
-    'quotes': ['error', 'single', {
-      'allowTemplateLiterals': true
-    }],
+    'quotes': ['error', 'single', { 'allowTemplateLiterals': true }],
+    'vue/no-use-v-if-with-v-for': 'warn',
   },
   overrides: [
     {

--- a/web/src/components/sudoku/StaticCell.vue
+++ b/web/src/components/sudoku/StaticCell.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="StaticCell">
+    <svg viewBox="0 0 100 100">
+      <text
+        v-if="cellValue"
+        x="50%"
+        y="50%"
+      >
+        {{ cellValue }}
+      </text>
+    </svg>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'StaticCell',
+
+  props: {
+    cellValue: {
+      type: Number,
+      required: true,
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.StaticCell {
+  border: 1px solid black;
+  position: relative;
+  margin-top: -1px;
+  margin-left: -1px;
+  user-select: none;
+
+  svg {
+    dominant-baseline: central;
+    text-anchor: middle;
+    width: 100%;
+
+    text {
+      font: 80px sans-serif;
+    }
+  }
+}
+</style>

--- a/web/src/components/sudoku/StaticGrid.vue
+++ b/web/src/components/sudoku/StaticGrid.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="StaticGrid__container">
+    <div
+      class="StaticGrid"
+      :class="gridCssClass"
+    >
+      <StaticCell
+        v-for="(cell) in cells"
+        :key="cell.index"
+        :cell-value="cell.value"
+      />
+
+      <span
+        v-for="division in numDivisions"
+        :key="division"
+        class="StaticGrid__vertical-division"
+        :style="{ left: `calc(${division * (100 / grid.subGridSize)}% - 1.5px)` }"
+      />
+
+      <span
+        v-for="division in numDivisions"
+        :key="division"
+        class="StaticGrid__horizontal-division"
+        :style="{ top: `calc(${division * (100 / grid.subGridSize)}% - 1.5px)` }"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import StaticCell from '@/components/sudoku/StaticCell.vue';
+
+import { createNamespacedHelpers } from 'vuex';
+
+const { mapGetters } = createNamespacedHelpers('grid');
+
+export default {
+  name: 'StaticGrid',
+  components: {
+    StaticCell,
+  },
+
+  computed: {
+    ...mapGetters({
+      cells: 'getCells',
+      grid: 'getGrid',
+    }),
+    gridCssClass() {
+      return {
+        'StaticGrid--two-by-two': this.grid.gridSize === 4,
+        'StaticGrid--three-by-three': this.grid.gridSize === 9,
+      };
+    },
+    numDivisions() {
+      return this.grid.subGridSize - 1;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.StaticGrid__container {
+  display: inline-block;
+  width: 100%;
+}
+
+.StaticGrid {
+  border: 3px solid black;
+  border-bottom: 2px solid black;
+  border-right: 2px solid black;
+  display: grid;
+  justify-items: stretch;
+  position: relative;
+}
+
+.StaticGrid--two-by-two {
+  grid-template-columns: repeat(4, auto);
+}
+
+.StaticGrid--three-by-three {
+  grid-template-columns: repeat(9, auto);
+}
+
+.StaticGrid__vertical-division {
+  background-color: black;
+  bottom: 0;
+  position: absolute;
+  top: 0;
+  width: 3px;
+}
+.StaticGrid__horizontal-division {
+  background-color: black;
+  left: 0;
+  position: absolute;
+  right: 0;
+  height: 3px;
+}
+</style>

--- a/web/src/lib/models/Grid.js
+++ b/web/src/lib/models/Grid.js
@@ -3,7 +3,8 @@ import SolutionValidator from '@/lib/SolutionValidator.js';
 
 export default class Grid {
   constructor(gridSize, cells) {
-    this.gridSize = gridSize;
+    this.gridSize = gridSize || 1;
+    this.subGridSize = Math.sqrt(this.gridSize);
     this.cells = cells;
   }
 

--- a/web/src/router/index.js
+++ b/web/src/router/index.js
@@ -1,5 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import Home from '../views/Home.vue';
+import About from '../views/About.vue';
+import View from '../views/View.vue';
 
 const routes = [
   {
@@ -13,7 +15,7 @@ const routes = [
   {
     path: '/about',
     name: 'About',
-    component: () => import(/* webpackChunkName: "about" */ '../views/About.vue'),
+    component: About,
     meta: {
       title: 'About - Rubydoku',
     },
@@ -24,6 +26,14 @@ const routes = [
     component: () => import(/* webpackChunkName: "play" */ '../views/Play.vue'),
     meta: {
       title: 'Play - Rubydoku',
+    },
+  },
+  {
+    path: '/view/:puzzleId',
+    name: 'View',
+    component: View,
+    meta: {
+      title: 'View Sudoku - Rubydoku',
     },
   },
 ];

--- a/web/src/views/View.vue
+++ b/web/src/views/View.vue
@@ -1,0 +1,37 @@
+<template>
+  <div>
+    <h1>View a Sudoku game</h1>
+
+    <StaticGrid class="View__grid" />
+  </div>
+</template>
+
+<script>
+import StaticGrid from '@/components/sudoku/StaticGrid.vue';
+import { createNamespacedHelpers } from 'vuex';
+
+const { mapGetters, mapActions } = createNamespacedHelpers('grid');
+
+export default {
+  components: {
+    StaticGrid,
+  },
+  computed: mapGetters({
+    grid: 'getGrid',
+  }),
+  mounted() {
+    const puzzleId = this.$route.params.puzzleId;
+    this.loadGridFromAPI({ puzzleId });
+  },
+  methods: mapActions([
+    'loadGridFromAPI',
+  ]),
+};
+</script>
+
+<style lang="scss" scoped>
+.View__grid {
+  height: 50vh;
+  width: 50vh;
+}
+</style>


### PR DESCRIPTION
Closes #31 

This creates a new grid component, `StaticGrid`, and `StaticCell`, to render a non-playable Sudoku grid, with the goal of displaying the puzzle as a thumbnail.

The static cell uses an SVG to render a responsive text, and the cell and grid themselves are also responsive and will scale to any size.

To visualise this new grid, a new page called `View` was added. This page is not on the menu as it's only temporary until #30  is done.